### PR TITLE
feat: update browser authentication to use API_TOKEN

### DIFF
--- a/server.js
+++ b/server.js
@@ -461,15 +461,6 @@ const datasets = [{
     ].join('\n'),
     inputs: ['url'],
 }, {
-    id: 'reuter_news',
-    dataset_id: 'gd_lyptx9h74wtlvpnfu',
-    description: [
-        'Quickly read structured reuter news data.',
-        'Requires a valid reuter news report URL.',
-        'This can be a cache lookup, so it can be more reliable than scraping',
-    ].join('\n'),
-    inputs: ['url'],
-}, {
     id: 'github_repository_file',
     dataset_id: 'gd_lyrexgxc24b3d4imjt',
     description: [


### PR DESCRIPTION
## Summary
Updates the browser tools authentication mechanism to use the API_TOKEN approach instead of the BROWSER_AUTH method, now we will use an optional parameter: BROWSER_ZONE, which will be used if a user wants to use browser zone that is name is not "mcp_browser"

## Changes
- Replace BROWSER_AUTH environment variable with API_TOKEN and optional BROWSER_ZONE
- Add dynamic credential retrieval from Account Managment API endpoints
- Fetch customer ID and zone password dynamically
- Add BROWSER_ZONE environment variable support (defaults to 'mcp_browser')
- Add error handling for missing browser zones (422 status)
- Update CDP endpoint calculation to use the new authentication format
- Removed duplicate  web_data_reuter_news tool to fix #17 

## Breaking Changes
- Users need to switch from BROWSER_AUTH to API_TOKEN environment variable

## Testing
- Tested with valid API_TOKEN and browser zone
- Tested error handling with invalid browser zone
- Verified backward compatibility with tools export
- Verified LF and Linting and fixed everything according to coding conventions 