### PR TITLE
Add Bright Data to MCP registry

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,53 @@
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags: ["v*"] 
+  workflow_dispatch: 
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Sync version in server.json with package.json
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Syncing version to: $VERSION"
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > tmp.json && mv tmp.json server.json
+          echo "Updated server.json:"
+          cat server.json
+
+      - name: Install MCP Publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Login to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+          files: |
+            server.json
+            package.json

--- a/server.json
+++ b/server.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.brightdata/brightdata-mcp",
+  "description": "Bright Data's Web MCP server enabling AI agents to search, extract & navigate the web",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/brightdata/brightdata-mcp",
+    "source": "github"
+  },
+  "version": "2.5.0",
+  "packages": [
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@brightdata/mcp",
+      "version": "2.5.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environment_variables": [
+        {
+          "description": "Your API key for Bright Data",
+          "is_required": true,
+          "format": "string",
+          "is_secret": true,
+          "name": "API_TOKEN"
+        },
+        {
+          "description": "Your unlocker zone name",
+          "is_required": false,
+          "format": "string",
+          "is_secret": false,
+          "name": "WEB_UNLOCKER_ZONE"
+        },
+        {
+          "description": "Your browser zone name",
+          "is_required": false,
+          "format": "string",
+          "is_secret": false,
+          "name": "BROWSER_ZONE"
+        },
+        {
+          "description": "To enable PRO_MODE - set to true",
+          "is_required": false,
+          "format": "boolean",
+          "is_secret": false,
+          "name": "PRO_MODE"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Add MCP Registry Auto-Publishing

Adds GitHub Actions workflow to automatically publish to MCP Registry on version tags.

## Changes
- **Added**: `.github/workflows/publish-mcp.yml` - Auto-publish workflow