### PR TITLE
add mcpName for registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,6 @@
         "server.js",
         "browser_tools.js",
         "browser_session.js"
-    ]
+    ],
+    "mcpName": "io.github.brightdata/brightdata-mcp"
 }


### PR DESCRIPTION
MCP registry requires this to be added to package.json for validation, see[ github actions ](https://github.com/brightdata/brightdata-mcp/actions/runs/17819417344/job/50658728127) for reference.
