### PR TITLE
fix: Revert to mcp sdk 1.21.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     },
     "license": "MIT",
     "dependencies": {
+       "@modelcontextprotocol/sdk": "1.21.2",
         "axios": "^1.11.0",
         "fastmcp": "^3.1.1",
         "playwright": "^1.51.1",


### PR DESCRIPTION
## Summary

Fix for an issue caused by a dependency change. When Bright Data MCP starts up it uses the fastmcp framework, and that framework automatically wires up completions support with the MCP SDK. In the latest SDK release (1.21.0), the SDK now refuses to register any completion handler unless the server explicitly advertises the completions capability. Unfortunately, FastMCP never declares that capability (it only sets tools, resources, prompts, and logging).