### PR TITLE
fix: Handle non-string Playwright snapshots without crashing

### DIFF
--- a/aria_snapshot_filter.js
+++ b/aria_snapshot_filter.js
@@ -65,6 +65,16 @@ export class Aria_snapshot_filter {
     }
 
     static filter_snapshot(snapshot_text){
+        if (typeof snapshot_text!=='string')
+        {
+            try {
+                return typeof snapshot_text==='object'
+                    ? JSON.stringify(snapshot_text, null, 2)
+                    : String(snapshot_text);
+            } catch(e){
+                return String(snapshot_text);
+            }
+        }
         try {
             const elements = this.parse_playwright_snapshot(snapshot_text);
             if (elements.length==0)


### PR DESCRIPTION
* Ensure filter_snapshot returns the raw _snapshotForAI output when it isn’t text, avoiding TypeErrors.
* Simplify parse_playwright_snapshot by removing redundant type check now that the guard/fallback lives in filter_snapshot.
* Keeps ARIA parsing intact for string snapshots while letting DOM snapshot logic proceed on unexpected types.
