### PR TITLE
feat: Add optional country targeting to browser tools

### DIFF
--- a/browser_tools.js
+++ b/browser_tools.js
@@ -7,7 +7,7 @@ let browser_zone = process.env.BROWSER_ZONE || 'mcp_browser';
 
 let open_session;
 let open_session_country = null;
-const require_browser = async(country)=>{
+const require_browser = async country=>{
     const normalized_country = country ? country.toLowerCase()
         : open_session_country;
 
@@ -24,7 +24,7 @@ const require_browser = async(country)=>{
     return open_session;
 };
 
-const calculate_cdp_endpoint = async(country)=>{
+const calculate_cdp_endpoint = async country=>{
     try {
         const status_response = await axios({
             url: 'https://api.brightdata.com/status',


### PR DESCRIPTION
## Description

* allow scraping_browser_navigate to accept a 2-letter ISO country code and route the CDP endpoint accordingly
* Build Bright Data CDP URL with country suffix when provided
* keep a single local browser session and only recreate when the country changes, preventing blank-page sessions on follow-up actions

### Related issues 
#90 

### Tests

* Tested using MCPJam - everything works as expected