### PR TITLE
feat: apply remark minification to scrape_batch results

### DIFF
--- a/server.js
+++ b/server.js
@@ -360,9 +360,12 @@ addTool({
                },
                headers: api_headers(ctx.clientName, 'scrape_batch'),
                responseType: 'text',
-           }).then(response => ({
+           }).then(async response=>({
                url,
-               content: response.data
+               content: (await remark()
+                   .use(strip, {keep: ['link', 'linkReference', 'code',
+                       'inlineCode']})
+                   .process(response.data)).value,
            }))
        );
 


### PR DESCRIPTION
## Summary

- Apply remark markdown minification to `scrape_batch` results, consistent with `scrape_as_markdown`
- Strips decorative markdown while preserving links, code blocks, and inline code