### PR TITLE
geo_fanout tool + classified retry/backoff policy (closes #104)

### DIFF
--- a/geo_utils.js
+++ b/geo_utils.js
@@ -79,6 +79,7 @@ function outcome_to_geo_status(outcome){
     switch (outcome)
     {
     case OUTCOME.SUCCESS: return GEO_STATUS.OK;
+    case OUTCOME.REDIRECT: return GEO_STATUS.REDIRECTED;
     case OUTCOME.BLOCKED: return GEO_STATUS.BLOCKED;
     case OUTCOME.RATE_LIMITED: return GEO_STATUS.RATE_LIMITED;
     default: return GEO_STATUS.ERROR;

--- a/geo_utils.js
+++ b/geo_utils.js
@@ -1,0 +1,158 @@
+'use strict'; /*jslint node:true es9:true*/
+
+// Pure helpers for the geo_fanout tool: validating the list of country exits
+// and turning a set of per-geo results into a single structured report where a
+// blocked / redirected / failed geo is a FIRST-CLASS classified result, not a
+// discarded error. No network or transport dependencies live here so the fanout
+// aggregation logic is unit-testable in isolation.
+
+import {classify_response, OUTCOME} from './retry_utils.js';
+
+// Per-geo status the caller sees in the aggregated report.
+export const GEO_STATUS = {
+    OK: 'ok',               // fetched successfully
+    BLOCKED: 'blocked',     // target refused this geo (403/451)
+    REDIRECTED: 'redirected', // 3xx to a different host/path (geo gating signal)
+    RATE_LIMITED: 'rate_limited',
+    ERROR: 'error',         // transient/fatal failure after retries
+};
+
+// Validate and normalize a list of 2-letter ISO country codes. Lowercases,
+// trims, dedupes (preserving first-seen order), and rejects malformed entries
+// loudly so a typo never becomes a silently-dropped exit. Returns the clean
+// array; throws Error on any invalid code (callers want fast, explicit failure).
+export function normalize_geos(geos){
+    if (!Array.isArray(geos) || geos.length===0)
+        throw new Error('geos must be a non-empty array of 2-letter codes');
+    const seen = new Set();
+    const out = [];
+    for (const raw of geos)
+    {
+        if (typeof raw!='string')
+            throw new Error(`invalid geo (not a string): ${JSON.stringify(raw)}`);
+        const code = raw.trim().toLowerCase();
+        if (!/^[a-z]{2}$/.test(code))
+            throw new Error(`invalid geo country code: "${raw}" `
+                +`(expected 2 letters, e.g. "us", "de")`);
+        if (seen.has(code))
+            continue;
+        seen.add(code);
+        out.push(code);
+    }
+    return out;
+}
+
+// Detect whether a successful-looking response is actually a geo redirect.
+// A 3xx with a Location header pointing at a different host is the classic
+// "Belgian visitor bounced to a different storefront" signal we must capture.
+function detect_redirect(status, headers, request_url){
+    if (!(status>=300 && status<400))
+        return null;
+    const location = read_header(headers, 'location');
+    if (!location)
+        return {redirected: true, location: null, cross_host: false};
+    let cross_host = false;
+    try {
+        const from = new URL(request_url);
+        const to = new URL(location, request_url);
+        cross_host = from.host!==to.host;
+    } catch(e){
+        cross_host = false;
+    }
+    return {redirected: true, location, cross_host};
+}
+
+function read_header(headers, name){
+    if (!headers || typeof headers!='object')
+        return undefined;
+    const target = name.toLowerCase();
+    for (const key of Object.keys(headers))
+    {
+        if (key.toLowerCase()===target)
+            return headers[key];
+    }
+    return undefined;
+}
+
+// Map one classified outcome to the per-geo report status.
+function outcome_to_geo_status(outcome){
+    switch (outcome)
+    {
+    case OUTCOME.SUCCESS: return GEO_STATUS.OK;
+    case OUTCOME.BLOCKED: return GEO_STATUS.BLOCKED;
+    case OUTCOME.RATE_LIMITED: return GEO_STATUS.RATE_LIMITED;
+    default: return GEO_STATUS.ERROR;
+    }
+}
+
+// Build the per-geo entry for a single settled attempt. `attempt` is the
+// normalized shape produced by the tool's executor:
+//   {geo, url, response:{status, headers, exit_ip?}}  on a completed request, or
+//   {geo, url, error:{code?, response?}}              on a thrown failure.
+// `now_ms` is injectable for deterministic Retry-After math under test.
+export function build_geo_entry(attempt, now_ms = Date.now()){
+    const obj = attempt && typeof attempt=='object' ? attempt : {};
+    const geo = typeof obj.geo=='string' ? obj.geo : 'unknown';
+    const url = typeof obj.url=='string' ? obj.url : null;
+    // Normalize to the shape classify_response understands: a thrown error keeps
+    // its {error} envelope; a completed request passes its {status, headers}.
+    const classify_input = obj.error ? {error: obj.error}
+        : (obj.response || {});
+    const classification = classify_response(classify_input, now_ms);
+    const status = classification.status;
+    const headers = obj.response ? obj.response.headers
+        : (obj.error && obj.error.response
+            ? obj.error.response.headers : undefined);
+    const exit_ip = obj.response
+        && typeof obj.response.exit_ip=='string'
+        ? obj.response.exit_ip : null;
+
+    const redirect = detect_redirect(status, headers, url);
+    let geo_status = outcome_to_geo_status(classification.outcome);
+    if (redirect && redirect.redirected)
+        geo_status = GEO_STATUS.REDIRECTED;
+
+    return {
+        geo,
+        url,
+        status: geo_status,
+        http_status: status,
+        exit_ip,
+        outcome: classification.outcome,
+        retry_after_ms: classification.retry_after_ms,
+        reason: classification.reason,
+        redirect: redirect || null,
+    };
+}
+
+// Aggregate all per-geo entries into one report. Every geo appears exactly once
+// regardless of success/failure; nothing is dropped. The summary makes the
+// "this geo was blocked / redirected" fact queryable at a glance.
+export function summarize_fanout(entries){
+    const list = Array.isArray(entries) ? entries : [];
+    const summary = {
+        total: list.length,
+        ok: 0,
+        blocked: 0,
+        redirected: 0,
+        rate_limited: 0,
+        error: 0,
+    };
+    for (const e of list)
+    {
+        switch (e.status)
+        {
+        case GEO_STATUS.OK: summary.ok++; break;
+        case GEO_STATUS.BLOCKED: summary.blocked++; break;
+        case GEO_STATUS.REDIRECTED: summary.redirected++; break;
+        case GEO_STATUS.RATE_LIMITED: summary.rate_limited++; break;
+        default: summary.error++; break;
+        }
+    }
+    return {
+        summary,
+        any_blocked: summary.blocked>0,
+        any_redirected: summary.redirected>0,
+        results: list,
+    };
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "server.js",
         "search_utils.js",
         "retry_utils.js",
+        "geo_utils.js",
         "browser_tools.js",
         "browser_session.js",
         "aria_snapshot_filter.js",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "files": [
         "server.js",
         "search_utils.js",
+        "retry_utils.js",
         "browser_tools.js",
         "browser_session.js",
         "aria_snapshot_filter.js",

--- a/retry_utils.js
+++ b/retry_utils.js
@@ -1,0 +1,220 @@
+'use strict'; /*jslint node:true es9:true*/
+
+// Pure, side-effect-free helpers for classifying Bright Data responses and
+// computing retry/backoff delays. Extracted so the retry policy is testable in
+// isolation and reusable across tools (search, scrape, batch, web_data).
+// See issue #104 (intermittent 502/504 from the gateway, no retry guidance).
+
+// Outcome taxonomy returned by classify_response. Each value tells the caller
+// what to do next, independent of any particular transport library.
+export const OUTCOME = {
+    SUCCESS: 'success',         // 2xx - use the body
+    RETRYABLE: 'retryable',     // transient - safe to retry after a backoff
+    RATE_LIMITED: 'rate_limited', // 429 - retry, but honor Retry-After if given
+    BLOCKED: 'blocked',         // target actively blocked us (403/451) - terminal
+    CLIENT_ERROR: 'client_error', // 4xx caller mistake - terminal, do not retry
+    FATAL: 'fatal',             // unexpected/unclassifiable - terminal
+};
+
+// Gateway/transport statuses that are safe to retry. 502/504 are the exact
+// symptoms reported in issue #104; 408/425 are slow/early-data conditions and
+// 500/503 are transient server states.
+const RETRYABLE_STATUS = new Set([408, 425, 500, 502, 503, 504]);
+
+// Statuses that mean "the target refused us"; retrying the same request will
+// not help, so we surface them as a first-class BLOCKED outcome rather than
+// burning retries or discarding the signal.
+const BLOCKED_STATUS = new Set([403, 451]);
+
+// Node/undici/axios network error codes with no HTTP status attached. These are
+// transient connectivity failures and are safe to retry.
+const RETRYABLE_NETWORK_CODES = new Set([
+    'ECONNRESET',
+    'ECONNREFUSED',
+    'ECONNABORTED',
+    'ETIMEDOUT',
+    'EAI_AGAIN',
+    'EPIPE',
+    'ENETUNREACH',
+    'ENETRESET',
+    'EHOSTUNREACH',
+    'UND_ERR_CONNECT_TIMEOUT',
+    'UND_ERR_HEADERS_TIMEOUT',
+    'UND_ERR_SOCKET',
+]);
+
+function is_finite_number(value){
+    return typeof value=='number' && Number.isFinite(value);
+}
+
+// Parse a Retry-After header value (RFC 9110). It is either a non-negative
+// integer number of seconds or an HTTP-date. Returns milliseconds, or null if
+// absent/unparseable/in the past. `now_ms` is injectable for deterministic tests.
+export function parse_retry_after(value, now_ms = Date.now()){
+    if (value===undefined || value===null)
+        return null;
+    const raw = String(value).trim();
+    if (!raw)
+        return null;
+    if (/^\d+$/.test(raw))
+    {
+        const seconds = parseInt(raw, 10);
+        return seconds * 1000;
+    }
+    const when = Date.parse(raw);
+    if (Number.isNaN(when))
+        return null;
+    const delta = when - now_ms;
+    return delta > 0 ? delta : 0;
+}
+
+// Read a header case-insensitively from a plain object. Bright Data / undici may
+// return header names in any case, so we never assume a fixed casing.
+function get_header(headers, name){
+    if (!headers || typeof headers!='object')
+        return undefined;
+    const target = name.toLowerCase();
+    for (const key of Object.keys(headers))
+    {
+        if (key.toLowerCase()===target)
+            return headers[key];
+    }
+    return undefined;
+}
+
+// Classify a response or thrown error into a stable OUTCOME plus the metadata a
+// retry loop needs. Accepts a normalized shape so it never depends on axios:
+//   {status, headers}            - a completed HTTP response, or
+//   {error: {code, response}}    - a thrown transport error (axios-style).
+// Returns {outcome, status|null, retry_after_ms|null, retryable, reason}.
+export function classify_response(input, now_ms = Date.now()){
+    const obj = input && typeof input=='object' ? input : {};
+    const err = obj.error && typeof obj.error=='object' ? obj.error : null;
+
+    // A thrown error may carry an HTTP response (server replied with a status)
+    // or only a network code (connection never completed).
+    const response = err ? err.response : obj;
+    const status = response && is_finite_number(response.status)
+        ? response.status : null;
+    const headers = response ? response.headers : undefined;
+    const retry_after_ms = parse_retry_after(get_header(headers, 'retry-after'),
+        now_ms);
+
+    if (status===null)
+    {
+        const code = err && typeof err.code=='string' ? err.code : null;
+        if (code && RETRYABLE_NETWORK_CODES.has(code))
+        {
+            return {outcome: OUTCOME.RETRYABLE, status: null,
+                retry_after_ms: null, retryable: true,
+                reason: `network error ${code}`};
+        }
+        return {outcome: OUTCOME.FATAL, status: null, retry_after_ms: null,
+            retryable: false,
+            reason: code ? `unhandled network error ${code}`
+                : 'no status and no network code'};
+    }
+
+    if (status>=200 && status<300)
+    {
+        return {outcome: OUTCOME.SUCCESS, status, retry_after_ms: null,
+            retryable: false, reason: `http ${status}`};
+    }
+
+    if (status===429)
+    {
+        return {outcome: OUTCOME.RATE_LIMITED, status, retry_after_ms,
+            retryable: true, reason: 'http 429 rate limited'};
+    }
+
+    if (BLOCKED_STATUS.has(status))
+    {
+        return {outcome: OUTCOME.BLOCKED, status, retry_after_ms: null,
+            retryable: false, reason: `http ${status} target blocked request`};
+    }
+
+    if (RETRYABLE_STATUS.has(status))
+    {
+        return {outcome: OUTCOME.RETRYABLE, status, retry_after_ms,
+            retryable: true, reason: `http ${status} transient gateway error`};
+    }
+
+    if (status>=400 && status<500)
+    {
+        return {outcome: OUTCOME.CLIENT_ERROR, status, retry_after_ms: null,
+            retryable: false, reason: `http ${status} client error`};
+    }
+
+    // Any other 5xx we did not enumerate: treat as retryable (transient by
+    // nature) rather than fatal, but cap via the caller's max_retries.
+    if (status>=500)
+    {
+        return {outcome: OUTCOME.RETRYABLE, status, retry_after_ms,
+            retryable: true, reason: `http ${status} server error`};
+    }
+
+    return {outcome: OUTCOME.FATAL, status, retry_after_ms: null,
+        retryable: false, reason: `http ${status} unclassified`};
+}
+
+// Default exponential-backoff parameters. base_ms doubles each attempt up to
+// max_ms, then full jitter is applied so concurrent callers (issue #104's burst
+// of 50+ calls) do not retry in lockstep and re-overload the gateway.
+export const DEFAULT_BACKOFF = {
+    base_ms: 500,
+    max_ms: 30000,
+    factor: 2,
+    jitter: 'full',
+};
+
+// Compute the delay (ms) before retry `attempt` (0-indexed: attempt 0 is the
+// wait before the 2nd try). A server-supplied retry_after_ms always wins and is
+// clamped to max_ms. `rng` is injectable (defaults to Math.random) so jittered
+// delays are deterministic under test.
+export function compute_backoff(attempt, opts = {}, rng = Math.random){
+    const base_ms = is_finite_number(opts.base_ms) && opts.base_ms>=0
+        ? opts.base_ms : DEFAULT_BACKOFF.base_ms;
+    const max_ms = is_finite_number(opts.max_ms) && opts.max_ms>=0
+        ? opts.max_ms : DEFAULT_BACKOFF.max_ms;
+    const factor = is_finite_number(opts.factor) && opts.factor>=1
+        ? opts.factor : DEFAULT_BACKOFF.factor;
+    const jitter = opts.jitter===undefined ? DEFAULT_BACKOFF.jitter
+        : opts.jitter;
+
+    if (is_finite_number(opts.retry_after_ms) && opts.retry_after_ms>=0)
+        return Math.min(opts.retry_after_ms, max_ms);
+
+    const safe_attempt = is_finite_number(attempt) && attempt>0
+        ? Math.floor(attempt) : 0;
+    const exponential = base_ms * Math.pow(factor, safe_attempt);
+    const capped = Math.min(exponential, max_ms);
+
+    if (jitter==='none')
+        return capped;
+    if (jitter==='equal')
+    {
+        // AWS "equal jitter": half fixed, half random.
+        const half = capped / 2;
+        return Math.round(half + rng() * half);
+    }
+    // "full jitter" (default): uniform random in [0, capped].
+    return Math.round(rng() * capped);
+}
+
+// Decide whether to retry given a classification and how many attempts remain.
+// `attempt` is 0-indexed (0 = the first try just failed). Returns
+// {retry, delay_ms, classification} so a loop has everything it needs.
+export function should_retry(classification, attempt, max_retries,
+    opts = {}, rng = Math.random){
+    const safe_max = is_finite_number(max_retries) && max_retries>=0
+        ? Math.floor(max_retries) : 0;
+    if (!classification || !classification.retryable)
+        return {retry: false, delay_ms: 0, classification};
+    if (attempt>=safe_max)
+        return {retry: false, delay_ms: 0, classification};
+    const delay_ms = compute_backoff(attempt, {
+        ...opts,
+        retry_after_ms: classification.retry_after_ms ?? undefined,
+    }, rng);
+    return {retry: true, delay_ms, classification};
+}

--- a/retry_utils.js
+++ b/retry_utils.js
@@ -9,6 +9,7 @@
 // what to do next, independent of any particular transport library.
 export const OUTCOME = {
     SUCCESS: 'success',         // 2xx - use the body
+    REDIRECT: 'redirect',       // 3xx - follow the Location (not an error)
     RETRYABLE: 'retryable',     // transient - safe to retry after a backoff
     RATE_LIMITED: 'rate_limited', // 429 - retry, but honor Retry-After if given
     BLOCKED: 'blocked',         // target actively blocked us (403/451) - terminal
@@ -47,20 +48,35 @@ function is_finite_number(value){
     return typeof value=='number' && Number.isFinite(value);
 }
 
+// An HTTP-date per RFC 9110: IMF-fixdate ("Sun, 06 Nov 1994 08:49:37 GMT"),
+// rfc850-date ("Sunday, 06-Nov-94 08:49:37 GMT"), or asctime
+// ("Sun Nov  6 08:49:37 1994"). We require a recognizable day-name prefix so a
+// bare number-like string ('1.5', '-3') is NEVER fed to the permissive
+// Date.parse (which would read it as a past date and clamp to an immediate retry).
+const HTTP_DATE_RE =
+    /^(mon|tue|wed|thu|fri|sat|sun)[a-z]*[,\s]/i;
+
 // Parse a Retry-After header value (RFC 9110). It is either a non-negative
 // integer number of seconds or an HTTP-date. Returns milliseconds, or null if
-// absent/unparseable/in the past. `now_ms` is injectable for deterministic tests.
+// absent/malformed/in the past. A malformed value (fractional '1.5', negative
+// '-3', junk) returns null so the caller falls back to its computed backoff
+// rather than retrying immediately. `now_ms` is injectable for deterministic tests.
 export function parse_retry_after(value, now_ms = Date.now()){
     if (value===undefined || value===null)
         return null;
     const raw = String(value).trim();
     if (!raw)
         return null;
+    // (a) a non-negative integer number of seconds.
     if (/^\d+$/.test(raw))
     {
         const seconds = parseInt(raw, 10);
         return seconds * 1000;
     }
+    // (b) a valid HTTP-date. Reject anything that is not date-shaped up front so
+    // permissive Date.parse never silently accepts numeric junk as a past date.
+    if (!HTTP_DATE_RE.test(raw))
+        return null;
     const when = Date.parse(raw);
     if (Number.isNaN(when))
         return null;
@@ -119,6 +135,16 @@ export function classify_response(input, now_ms = Date.now()){
     {
         return {outcome: OUTCOME.SUCCESS, status, retry_after_ms: null,
             retryable: false, reason: `http ${status}`};
+    }
+
+    // 3xx: a redirect, not an error. axios follows these transparently, so one
+    // surfacing here is a terminal-for-this-call signal to follow/report (the
+    // geo_fanout tool reads it as a geo-gating REDIRECTED signal). It is neither
+    // a retryable gateway error nor a hard fatal, hence its own outcome.
+    if (status>=300 && status<400)
+    {
+        return {outcome: OUTCOME.REDIRECT, status, retry_after_ms: null,
+            retryable: false, reason: `http ${status} redirect`};
     }
 
     if (status===429)

--- a/server.js
+++ b/server.js
@@ -8,6 +8,8 @@ import prompts from './prompts.js';
 import {GROUPS} from './tool_groups.js';
 import {parse_google_search_response} from './search_utils.js';
 import {classify_response, should_retry} from './retry_utils.js';
+import {normalize_geos, build_geo_entry, summarize_fanout}
+    from './geo_utils.js';
 import {createRequire} from 'node:module';
 import {remark} from 'remark';
 import strip from 'strip-markdown';
@@ -23,7 +25,7 @@ const base_timeout = process.env.BASE_TIMEOUT
 const base_max_retries = Math.min(
     parseInt(process.env.BASE_MAX_RETRIES || '0', 10), 3);
 const pro_mode_tools = ['search_engine', 'scrape_as_markdown',
-    'search_engine_batch', 'scrape_batch', 'discover'];
+    'search_engine_batch', 'scrape_batch', 'discover', 'geo_fanout'];
 const tool_groups = process.env.GROUPS ?
     process.env.GROUPS.split(',').map(g=>g.trim().toLowerCase())
         .filter(Boolean) : [];
@@ -409,6 +411,69 @@ addTool({
        const results = await Promise.allSettled(scrapePromises);
        return JSON.stringify(results, null, 2);
    }),
+});
+
+addTool({
+    name: 'geo_fanout',
+    description: 'Fetch the SAME url from multiple country exits in parallel and '
+        +'return one structured report. A geo that is blocked (403/451), '
+        +'redirected (3xx to a different host), rate-limited (429) or fails '
+        +'transiently becomes a FIRST-CLASS classified result - not a discarded '
+        +'error. Ideal for detecting geo-gating, regional price/availability '
+        +'differences, and access denial across countries.',
+    annotations: {
+        title: 'Geo Fanout',
+        readOnlyHint: true,
+        openWorldHint: true,
+    },
+    parameters: z.object({
+        url: z.string().url(),
+        countries: z.array(z.string().length(2))
+            .min(1)
+            .max(10)
+            .describe('2-letter ISO country codes to fan the request across '
+                +'(e.g., ["de", "be", "fr"]). Deduped; max 10.'),
+        data_format: z.enum(['raw', 'markdown'])
+            .optional()
+            .default('markdown')
+            .describe('Response body format per geo (default: markdown).'),
+    }),
+    execute: tool_fn('geo_fanout', async({url, countries, data_format}, ctx)=>{
+        const geos = normalize_geos(countries);
+        const now = Date.now();
+        const attempts = geos.map(geo=>(async()=>{
+            try {
+                const response = await base_request({
+                    url: 'https://api.brightdata.com/request',
+                    method: 'POST',
+                    data: {
+                        url,
+                        zone: unlocker_zone,
+                        format: 'raw',
+                        data_format,
+                        country: geo,
+                    },
+                    headers: api_headers(ctx.clientName, 'geo_fanout'),
+                    responseType: 'text',
+                });
+                const exit_ip = response.headers?.['x-brd-ip']
+                    || response.headers?.['x-luminati-ip'] || null;
+                return build_geo_entry({
+                    geo,
+                    url,
+                    response: {
+                        status: response.status,
+                        headers: response.headers,
+                        ...exit_ip ? {exit_ip} : {},
+                    },
+                }, now);
+            } catch(e){
+                return build_geo_entry({geo, url, error: e}, now);
+            }
+        })());
+        const entries = await Promise.all(attempts);
+        return JSON.stringify(summarize_fanout(entries), null, 2);
+    }),
 });
 
 addTool({

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ import {tools as browser_tools} from './browser_tools.js';
 import prompts from './prompts.js';
 import {GROUPS} from './tool_groups.js';
 import {parse_google_search_response} from './search_utils.js';
+import {classify_response, should_retry} from './retry_utils.js';
 import {createRequire} from 'node:module';
 import {remark} from 'remark';
 import strip from 'strip-markdown';
@@ -69,6 +70,19 @@ const rate_limit_config = parse_rate_limit(process.env.RATE_LIMIT);
 if (!api_token)
     throw new Error('Cannot run MCP server without API_TOKEN env');
 
+const sleep = ms=>new Promise(resolve=>setTimeout(resolve, ms));
+
+// Backoff knobs (overridable via env) used by base_request and geo_fanout.
+// Issue #104: bursts of MCP calls hit intermittent 502/504 from the gateway and
+// there was no backoff guidance. We now classify each failure and retry only the
+// transient ones with exponential backoff + full jitter, honoring Retry-After.
+const backoff_opts = {
+    base_ms: parseInt(process.env.BASE_BACKOFF_MS || '500', 10),
+    max_ms: parseInt(process.env.MAX_BACKOFF_MS || '30000', 10),
+    factor: 2,
+    jitter: 'full',
+};
+
 async function base_request(config){
     let last_err;
     for (let attempt = 0; attempt <= base_max_retries; attempt++)
@@ -77,11 +91,14 @@ async function base_request(config){
             return await axios({...config, timeout: base_timeout});
         } catch(e){
             last_err = e;
-            if (e.response?.status && e.response.status >= 400
-                && e.response.status < 500)
-            {
+            const classification = classify_response({error: e});
+            const decision = should_retry(classification, attempt,
+                base_max_retries, backoff_opts);
+            if (!decision.retry)
                 throw e;
-            }
+            console.error(`[base_request] ${classification.reason}; retry `
+                +`${attempt + 1}/${base_max_retries} in ${decision.delay_ms}ms`);
+            await sleep(decision.delay_ms);
         }
     }
     throw last_err;

--- a/test/geo-fanout-tool.test.js
+++ b/test/geo-fanout-tool.test.js
@@ -1,0 +1,40 @@
+'use strict'; /*jslint node:true es9:true*/
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {fileURLToPath} from 'node:url';
+import {dirname, resolve} from 'node:path';
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const test_dir = dirname(fileURLToPath(import.meta.url));
+const repo_root = resolve(test_dir, '..');
+
+test('geo_fanout tool is registered and well-formed over stdio', async()=>{
+    const env = {
+        ...process.env,
+        API_TOKEN: 'dummy-token',
+        PRO_MODE: 'true',
+    };
+    const client = new Client(
+        {name: 'geo-fanout-test', version: '0.0.1'},
+        {capabilities: {tools: {}}});
+    const transport = new StdioClientTransport({
+        command: process.execPath,
+        args: ['server.js'],
+        cwd: repo_root,
+        env,
+    });
+    try {
+        await client.connect(transport);
+        const {tools} = await client.listTools();
+        const geo_fanout = tools.find(tool=>tool.name=='geo_fanout');
+        assert.ok(geo_fanout, 'geo_fanout tool is exposed');
+        assert.match(geo_fanout.description, /first-class/i,
+            'description documents first-class classified results');
+        const props = geo_fanout.inputSchema?.properties || {};
+        assert.ok(props.url, 'geo_fanout exposes a url parameter');
+        assert.ok(props.countries, 'geo_fanout exposes a countries parameter');
+    } finally {
+        await client.close();
+    }
+});

--- a/test/geo-utils.test.js
+++ b/test/geo-utils.test.js
@@ -1,0 +1,187 @@
+'use strict'; /*jslint node:true es9:true*/
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    GEO_STATUS,
+    normalize_geos,
+    build_geo_entry,
+    summarize_fanout,
+} from '../geo_utils.js';
+
+const NOW = Date.parse('2026-01-19T20:51:08Z');
+
+const normalize_ok_cases = [
+    {
+        name: 'lowercases and trims',
+        input: [' US ', 'De'],
+        expected: ['us', 'de'],
+    },
+    {
+        name: 'dedupes preserving first-seen order',
+        input: ['de', 'be', 'DE', 'be', 'fr'],
+        expected: ['de', 'be', 'fr'],
+    },
+    {
+        name: 'single code',
+        input: ['gb'],
+        expected: ['gb'],
+    },
+];
+
+test('normalize_geos valid cases (table-driven)', ()=>{
+    for (const tc of normalize_ok_cases)
+    {
+        assert.deepEqual(normalize_geos(tc.input), tc.expected, tc.name);
+    }
+});
+
+const normalize_throw_cases = [
+    {name: 'empty array throws', input: [], match: /non-empty array/},
+    {name: 'not an array throws', input: 'us', match: /non-empty array/},
+    {name: 'three-letter code throws', input: ['usa'],
+        match: /invalid geo country code/},
+    {name: 'one-letter code throws', input: ['u'],
+        match: /invalid geo country code/},
+    {name: 'digits throw', input: ['12'], match: /invalid geo country code/},
+    {name: 'non-string entry throws', input: [42], match: /not a string/},
+];
+
+test('normalize_geos invalid cases throw loudly (table-driven)', ()=>{
+    for (const tc of normalize_throw_cases)
+    {
+        assert.throws(()=>normalize_geos(tc.input), tc.match, tc.name);
+    }
+});
+
+const entry_cases = [
+    {
+        name: '200 -> ok',
+        attempt: {geo: 'de', url: 'https://shop.example/p/1',
+            response: {status: 200, headers: {}, exit_ip: '1.2.3.4'}},
+        status: GEO_STATUS.OK,
+        http_status: 200,
+        exit_ip: '1.2.3.4',
+    },
+    {
+        name: '403 -> blocked as first-class result (not discarded)',
+        attempt: {geo: 'be', url: 'https://shop.example/p/1',
+            error: {response: {status: 403, headers: {}}}},
+        status: GEO_STATUS.BLOCKED,
+        http_status: 403,
+    },
+    {
+        name: '451 -> blocked',
+        attempt: {geo: 'be', url: 'https://shop.example/p/1',
+            error: {response: {status: 451, headers: {}}}},
+        status: GEO_STATUS.BLOCKED,
+        http_status: 451,
+    },
+    {
+        name: '302 cross-host -> redirected (geo gating signal)',
+        attempt: {geo: 'be', url: 'https://de.shop.example/p/1',
+            response: {status: 302,
+                headers: {location: 'https://be.shop.example/blocked'}}},
+        status: GEO_STATUS.REDIRECTED,
+        http_status: 302,
+    },
+    {
+        name: '301 same-host -> still redirected, cross_host false',
+        attempt: {geo: 'de', url: 'https://shop.example/p/1',
+            response: {status: 301,
+                headers: {location: 'https://shop.example/p/1/'}}},
+        status: GEO_STATUS.REDIRECTED,
+        http_status: 301,
+    },
+    {
+        name: '429 -> rate_limited with retry_after',
+        attempt: {geo: 'fr', url: 'https://shop.example/p/1',
+            error: {response: {status: 429,
+                headers: {'retry-after': '3'}}}},
+        status: GEO_STATUS.RATE_LIMITED,
+        http_status: 429,
+        retry_after_ms: 3000,
+    },
+    {
+        name: '502 -> error (transient, surfaced not dropped)',
+        attempt: {geo: 'it', url: 'https://shop.example/p/1',
+            error: {response: {status: 502, headers: {}}}},
+        status: GEO_STATUS.ERROR,
+        http_status: 502,
+    },
+    {
+        name: 'network error -> error with null http_status',
+        attempt: {geo: 'es', url: 'https://shop.example/p/1',
+            error: {code: 'ECONNRESET'}},
+        status: GEO_STATUS.ERROR,
+        http_status: null,
+    },
+];
+
+test('build_geo_entry classifies each geo as first-class (table-driven)', ()=>{
+    for (const tc of entry_cases)
+    {
+        const e = build_geo_entry(tc.attempt, NOW);
+        assert.equal(e.status, tc.status, `${tc.name}: status`);
+        assert.equal(e.http_status, tc.http_status,
+            `${tc.name}: http_status`);
+        assert.equal(e.geo, tc.attempt.geo, `${tc.name}: geo preserved`);
+        if (tc.exit_ip!==undefined)
+            assert.equal(e.exit_ip, tc.exit_ip, `${tc.name}: exit_ip`);
+        if (tc.retry_after_ms!==undefined)
+        {
+            assert.equal(e.retry_after_ms, tc.retry_after_ms,
+                `${tc.name}: retry_after_ms`);
+        }
+        assert.equal(typeof e.reason, 'string', `${tc.name}: reason string`);
+    }
+});
+
+test('build_geo_entry marks cross_host redirect correctly', ()=>{
+    const cross = build_geo_entry({geo: 'be',
+        url: 'https://de.shop.example/p/1',
+        response: {status: 302,
+            headers: {location: 'https://be.shop.example/x'}}}, NOW);
+    assert.equal(cross.redirect.cross_host, true);
+
+    const same = build_geo_entry({geo: 'de',
+        url: 'https://shop.example/p/1',
+        response: {status: 301,
+            headers: {location: 'https://shop.example/p/1/'}}}, NOW);
+    assert.equal(same.redirect.cross_host, false);
+});
+
+test('summarize_fanout counts every geo with none dropped', ()=>{
+    const entries = [
+        build_geo_entry({geo: 'de', url: 'https://shop.example/p',
+            response: {status: 200, headers: {}}}, NOW),
+        build_geo_entry({geo: 'be', url: 'https://shop.example/p',
+            error: {response: {status: 403, headers: {}}}}, NOW),
+        build_geo_entry({geo: 'fr', url: 'https://de.shop.example/p',
+            response: {status: 302,
+                headers: {location: 'https://fr.shop.example/x'}}}, NOW),
+        build_geo_entry({geo: 'it', url: 'https://shop.example/p',
+            error: {response: {status: 429,
+                headers: {'retry-after': '1'}}}}, NOW),
+        build_geo_entry({geo: 'es', url: 'https://shop.example/p',
+            error: {code: 'ETIMEDOUT'}}, NOW),
+    ];
+    const report = summarize_fanout(entries);
+    assert.equal(report.summary.total, 5);
+    assert.equal(report.summary.ok, 1);
+    assert.equal(report.summary.blocked, 1);
+    assert.equal(report.summary.redirected, 1);
+    assert.equal(report.summary.rate_limited, 1);
+    assert.equal(report.summary.error, 1);
+    assert.equal(report.any_blocked, true);
+    assert.equal(report.any_redirected, true);
+    assert.equal(report.results.length, 5,
+        'every geo is present in results, nothing discarded');
+});
+
+test('summarize_fanout handles empty input without crashing', ()=>{
+    const report = summarize_fanout([]);
+    assert.equal(report.summary.total, 0);
+    assert.equal(report.any_blocked, false);
+    assert.equal(report.any_redirected, false);
+    assert.deepEqual(report.results, []);
+});

--- a/test/geo-utils.test.js
+++ b/test/geo-utils.test.js
@@ -7,6 +7,7 @@ import {
     build_geo_entry,
     summarize_fanout,
 } from '../geo_utils.js';
+import {OUTCOME} from '../retry_utils.js';
 
 const NOW = Date.parse('2026-01-19T20:51:08Z');
 
@@ -93,6 +94,14 @@ const entry_cases = [
         http_status: 301,
     },
     {
+        name: '303 with no Location -> redirected (self-consistent outcome)',
+        attempt: {geo: 'be', url: 'https://shop.example/p/1',
+            response: {status: 303, headers: {}}},
+        status: GEO_STATUS.REDIRECTED,
+        http_status: 303,
+        outcome: OUTCOME.REDIRECT,
+    },
+    {
         name: '429 -> rate_limited with retry_after',
         attempt: {geo: 'fr', url: 'https://shop.example/p/1',
             error: {response: {status: 429,
@@ -131,6 +140,11 @@ test('build_geo_entry classifies each geo as first-class (table-driven)', ()=>{
         {
             assert.equal(e.retry_after_ms, tc.retry_after_ms,
                 `${tc.name}: retry_after_ms`);
+        }
+        if (tc.outcome!==undefined)
+        {
+            assert.equal(e.outcome, tc.outcome,
+                `${tc.name}: outcome self-consistent with status`);
         }
         assert.equal(typeof e.reason, 'string', `${tc.name}: reason string`);
     }

--- a/test/retry-utils.test.js
+++ b/test/retry-utils.test.js
@@ -1,0 +1,362 @@
+'use strict'; /*jslint node:true es9:true*/
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    OUTCOME,
+    classify_response,
+    compute_backoff,
+    parse_retry_after,
+    should_retry,
+} from '../retry_utils.js';
+
+// Fixed clock so HTTP-date Retry-After cases are deterministic.
+const NOW = Date.parse('2026-01-19T20:51:08Z');
+
+const classify_cases = [
+    {
+        name: '200 is success, not retryable',
+        input: {status: 200, headers: {}},
+        outcome: OUTCOME.SUCCESS,
+        retryable: false,
+        retry_after_ms: null,
+    },
+    {
+        name: '204 is success',
+        input: {status: 204, headers: {}},
+        outcome: OUTCOME.SUCCESS,
+        retryable: false,
+    },
+    {
+        name: '502 from gateway is retryable (issue #104)',
+        input: {error: {response: {status: 502, headers: {}}}},
+        outcome: OUTCOME.RETRYABLE,
+        retryable: true,
+    },
+    {
+        name: '504 gateway timeout is retryable (issue #104)',
+        input: {error: {response: {status: 504, headers: {}}}},
+        outcome: OUTCOME.RETRYABLE,
+        retryable: true,
+    },
+    {
+        name: '500 is retryable',
+        input: {error: {response: {status: 500, headers: {}}}},
+        outcome: OUTCOME.RETRYABLE,
+        retryable: true,
+    },
+    {
+        name: '503 is retryable',
+        input: {error: {response: {status: 503, headers: {}}}},
+        outcome: OUTCOME.RETRYABLE,
+        retryable: true,
+    },
+    {
+        name: '408 request timeout is retryable',
+        input: {error: {response: {status: 408, headers: {}}}},
+        outcome: OUTCOME.RETRYABLE,
+        retryable: true,
+    },
+    {
+        name: 'unenumerated 5xx (599) falls back to retryable',
+        input: {error: {response: {status: 599, headers: {}}}},
+        outcome: OUTCOME.RETRYABLE,
+        retryable: true,
+    },
+    {
+        name: '429 is rate_limited and retryable',
+        input: {error: {response: {status: 429, headers: {}}}},
+        outcome: OUTCOME.RATE_LIMITED,
+        retryable: true,
+    },
+    {
+        name: '429 surfaces numeric Retry-After in ms',
+        input: {error: {response: {status: 429,
+            headers: {'retry-after': '2'}}}},
+        outcome: OUTCOME.RATE_LIMITED,
+        retryable: true,
+        retry_after_ms: 2000,
+    },
+    {
+        name: '429 surfaces uppercase Retry-After header',
+        input: {error: {response: {status: 429,
+            headers: {'Retry-After': '5'}}}},
+        outcome: OUTCOME.RATE_LIMITED,
+        retryable: true,
+        retry_after_ms: 5000,
+    },
+    {
+        name: '503 surfaces HTTP-date Retry-After relative to now',
+        input: {error: {response: {status: 503,
+            headers: {'retry-after': 'Mon, 19 Jan 2026 20:51:18 GMT'}}}},
+        outcome: OUTCOME.RETRYABLE,
+        retryable: true,
+        retry_after_ms: 10000,
+    },
+    {
+        name: '403 is a first-class BLOCKED outcome, not a discarded error',
+        input: {error: {response: {status: 403, headers: {}}}},
+        outcome: OUTCOME.BLOCKED,
+        retryable: false,
+    },
+    {
+        name: '451 (unavailable for legal reasons) is BLOCKED',
+        input: {error: {response: {status: 451, headers: {}}}},
+        outcome: OUTCOME.BLOCKED,
+        retryable: false,
+    },
+    {
+        name: '400 is a terminal client error',
+        input: {error: {response: {status: 400, headers: {}}}},
+        outcome: OUTCOME.CLIENT_ERROR,
+        retryable: false,
+    },
+    {
+        name: '401 is a terminal client error',
+        input: {error: {response: {status: 401, headers: {}}}},
+        outcome: OUTCOME.CLIENT_ERROR,
+        retryable: false,
+    },
+    {
+        name: '404 is a terminal client error',
+        input: {error: {response: {status: 404, headers: {}}}},
+        outcome: OUTCOME.CLIENT_ERROR,
+        retryable: false,
+    },
+    {
+        name: 'ECONNRESET network error is retryable',
+        input: {error: {code: 'ECONNRESET'}},
+        outcome: OUTCOME.RETRYABLE,
+        retryable: true,
+    },
+    {
+        name: 'ETIMEDOUT network error is retryable',
+        input: {error: {code: 'ETIMEDOUT'}},
+        outcome: OUTCOME.RETRYABLE,
+        retryable: true,
+    },
+    {
+        name: 'undici connect timeout is retryable',
+        input: {error: {code: 'UND_ERR_CONNECT_TIMEOUT'}},
+        outcome: OUTCOME.RETRYABLE,
+        retryable: true,
+    },
+    {
+        name: 'unknown network code is fatal, never silently retried',
+        input: {error: {code: 'ESOMETHINGWEIRD'}},
+        outcome: OUTCOME.FATAL,
+        retryable: false,
+    },
+    {
+        name: 'no status and no code is fatal',
+        input: {error: {}},
+        outcome: OUTCOME.FATAL,
+        retryable: false,
+    },
+    {
+        name: 'non-object input is fatal, not a crash',
+        input: null,
+        outcome: OUTCOME.FATAL,
+        retryable: false,
+    },
+];
+
+test('classify_response taxonomy (table-driven)', ()=>{
+    for (const tc of classify_cases)
+    {
+        const got = classify_response(tc.input, NOW);
+        assert.equal(got.outcome, tc.outcome,
+            `${tc.name}: outcome ${got.outcome} != ${tc.outcome}`);
+        assert.equal(got.retryable, tc.retryable,
+            `${tc.name}: retryable ${got.retryable} != ${tc.retryable}`);
+        if (tc.retry_after_ms!==undefined)
+        {
+            assert.equal(got.retry_after_ms, tc.retry_after_ms,
+                `${tc.name}: retry_after_ms ${got.retry_after_ms} `
+                +`!= ${tc.retry_after_ms}`);
+        }
+        assert.equal(typeof got.reason, 'string',
+            `${tc.name}: reason should be a string`);
+    }
+});
+
+const parse_retry_after_cases = [
+    {name: 'undefined -> null', value: undefined, expected: null},
+    {name: 'null -> null', value: null, expected: null},
+    {name: 'empty string -> null', value: '   ', expected: null},
+    {name: 'integer seconds -> ms', value: '3', expected: 3000},
+    {name: 'zero seconds -> 0', value: '0', expected: 0},
+    {name: 'garbage -> null', value: 'soon', expected: null},
+    {
+        name: 'future HTTP-date -> positive ms',
+        value: 'Mon, 19 Jan 2026 20:51:18 GMT',
+        expected: 10000,
+    },
+    {
+        name: 'past HTTP-date clamps to 0',
+        value: 'Mon, 19 Jan 2026 20:51:00 GMT',
+        expected: 0,
+    },
+];
+
+test('parse_retry_after (table-driven)', ()=>{
+    for (const tc of parse_retry_after_cases)
+    {
+        const got = parse_retry_after(tc.value, NOW);
+        assert.equal(got, tc.expected,
+            `${tc.name}: got ${got} expected ${tc.expected}`);
+    }
+});
+
+const backoff_cases = [
+    {
+        name: 'no jitter, attempt 0 -> base',
+        attempt: 0,
+        opts: {base_ms: 500, jitter: 'none'},
+        expected: 500,
+    },
+    {
+        name: 'no jitter, attempt 1 -> base*factor',
+        attempt: 1,
+        opts: {base_ms: 500, factor: 2, jitter: 'none'},
+        expected: 1000,
+    },
+    {
+        name: 'no jitter, attempt 3 -> base*factor^3',
+        attempt: 3,
+        opts: {base_ms: 500, factor: 2, jitter: 'none'},
+        expected: 4000,
+    },
+    {
+        name: 'no jitter caps at max_ms',
+        attempt: 10,
+        opts: {base_ms: 500, factor: 2, max_ms: 30000, jitter: 'none'},
+        expected: 30000,
+    },
+    {
+        name: 'retry_after_ms overrides exponential',
+        attempt: 5,
+        opts: {base_ms: 500, retry_after_ms: 2000, jitter: 'none'},
+        expected: 2000,
+    },
+    {
+        name: 'retry_after_ms is clamped to max_ms',
+        attempt: 0,
+        opts: {retry_after_ms: 120000, max_ms: 30000, jitter: 'none'},
+        expected: 30000,
+    },
+    {
+        name: 'full jitter with rng=0 -> 0',
+        attempt: 2,
+        opts: {base_ms: 500, jitter: 'full'},
+        rng: ()=>0,
+        expected: 0,
+    },
+    {
+        name: 'full jitter with rng=1 -> capped value',
+        attempt: 2,
+        opts: {base_ms: 500, factor: 2, jitter: 'full'},
+        rng: ()=>1,
+        expected: 2000,
+    },
+    {
+        name: 'equal jitter with rng=0 -> half capped',
+        attempt: 2,
+        opts: {base_ms: 500, factor: 2, jitter: 'equal'},
+        rng: ()=>0,
+        expected: 1000,
+    },
+    {
+        name: 'equal jitter with rng=1 -> full capped',
+        attempt: 2,
+        opts: {base_ms: 500, factor: 2, jitter: 'equal'},
+        rng: ()=>1,
+        expected: 2000,
+    },
+    {
+        name: 'negative attempt is floored to 0',
+        attempt: -3,
+        opts: {base_ms: 500, jitter: 'none'},
+        expected: 500,
+    },
+    {
+        name: 'defaults applied when opts empty',
+        attempt: 0,
+        opts: {jitter: 'none'},
+        expected: 500,
+    },
+];
+
+test('compute_backoff (table-driven)', ()=>{
+    for (const tc of backoff_cases)
+    {
+        const rng = tc.rng || (()=>0.5);
+        const got = compute_backoff(tc.attempt, tc.opts, rng);
+        assert.equal(got, tc.expected,
+            `${tc.name}: got ${got} expected ${tc.expected}`);
+    }
+});
+
+test('full jitter stays within [0, capped] across the rng range', ()=>{
+    const opts = {base_ms: 500, factor: 2, max_ms: 30000, jitter: 'full'};
+    for (const r of [0, 0.01, 0.25, 0.5, 0.75, 0.99, 1])
+    {
+        const delay = compute_backoff(3, opts, ()=>r);
+        assert.ok(delay>=0, `delay ${delay} should be >= 0`);
+        assert.ok(delay<=4000, `delay ${delay} should be <= capped 4000`);
+    }
+});
+
+const should_retry_cases = [
+    {
+        name: 'retryable within budget -> retry',
+        classification: {retryable: true, retry_after_ms: null},
+        attempt: 0,
+        max_retries: 3,
+        expect_retry: true,
+    },
+    {
+        name: 'retryable but budget exhausted -> stop',
+        classification: {retryable: true, retry_after_ms: null},
+        attempt: 3,
+        max_retries: 3,
+        expect_retry: false,
+    },
+    {
+        name: 'non-retryable -> never retry',
+        classification: {retryable: false, retry_after_ms: null},
+        attempt: 0,
+        max_retries: 3,
+        expect_retry: false,
+    },
+    {
+        name: 'missing classification -> never retry',
+        classification: null,
+        attempt: 0,
+        max_retries: 3,
+        expect_retry: false,
+    },
+    {
+        name: 'retry honors classification retry_after_ms',
+        classification: {retryable: true, retry_after_ms: 2000},
+        attempt: 0,
+        max_retries: 3,
+        opts: {jitter: 'none', max_ms: 30000},
+        expect_retry: true,
+        expect_delay: 2000,
+    },
+];
+
+test('should_retry budget + delay (table-driven)', ()=>{
+    for (const tc of should_retry_cases)
+    {
+        const got = should_retry(tc.classification, tc.attempt, tc.max_retries,
+            tc.opts || {jitter: 'none'}, ()=>0.5);
+        assert.equal(got.retry, tc.expect_retry,
+            `${tc.name}: retry ${got.retry} != ${tc.expect_retry}`);
+        if (tc.expect_delay!==undefined)
+        {
+            assert.equal(got.delay_ms, tc.expect_delay,
+                `${tc.name}: delay ${got.delay_ms} != ${tc.expect_delay}`);
+        }
+    }
+});

--- a/test/retry-utils.test.js
+++ b/test/retry-utils.test.js
@@ -63,6 +63,25 @@ const classify_cases = [
         retryable: true,
     },
     {
+        name: '301 is a redirect, not fatal (self-consistent outcome)',
+        input: {status: 301, headers: {location: 'https://shop.example/x'}},
+        outcome: OUTCOME.REDIRECT,
+        retryable: false,
+        retry_after_ms: null,
+    },
+    {
+        name: '302 is a redirect, never retried',
+        input: {error: {response: {status: 302, headers: {}}}},
+        outcome: OUTCOME.REDIRECT,
+        retryable: false,
+    },
+    {
+        name: '307 temporary redirect is a redirect outcome',
+        input: {status: 307, headers: {}},
+        outcome: OUTCOME.REDIRECT,
+        retryable: false,
+    },
+    {
         name: '429 is rate_limited and retryable',
         input: {error: {response: {status: 429, headers: {}}}},
         outcome: OUTCOME.RATE_LIMITED,
@@ -184,8 +203,17 @@ const parse_retry_after_cases = [
     {name: 'null -> null', value: null, expected: null},
     {name: 'empty string -> null', value: '   ', expected: null},
     {name: 'integer seconds -> ms', value: '3', expected: 3000},
+    {name: 'large integer seconds -> ms', value: '120', expected: 120000},
     {name: 'zero seconds -> 0', value: '0', expected: 0},
     {name: 'garbage -> null', value: 'soon', expected: null},
+    // Strictness: fractional/negative/number-like junk must be null (fall back to
+    // computed backoff), NOT 0 (an immediate retry via permissive Date.parse).
+    {name: 'fractional seconds -> null (not 0)', value: '1.5', expected: null},
+    {name: 'negative seconds -> null (not 0)', value: '-3', expected: null},
+    {name: 'leading-plus -> null', value: '+5', expected: null},
+    {name: 'trailing junk -> null', value: '5s', expected: null},
+    {name: 'numeric-with-space -> null', value: '5 ', expected: 5000},
+    {name: 'date-shaped junk -> null', value: 'Mon, not a date', expected: null},
     {
         name: 'future HTTP-date -> positive ms',
         value: 'Mon, 19 Jan 2026 20:51:18 GMT',
@@ -324,6 +352,13 @@ const should_retry_cases = [
     {
         name: 'non-retryable -> never retry',
         classification: {retryable: false, retry_after_ms: null},
+        attempt: 0,
+        max_retries: 3,
+        expect_retry: false,
+    },
+    {
+        name: 'redirect classification -> never retried (no 3xx loop)',
+        classification: classify_response({status: 302, headers: {}}),
         attempt: 0,
         max_retries: 3,
         expect_retry: false,

--- a/tool_groups.js
+++ b/tool_groups.js
@@ -134,6 +134,7 @@ export const GROUPS = {
             ...base_tools,
             'search_engine_batch',
             'scrape_batch',
+            'geo_fanout',
             'scrape_as_html',
             'extract',
             'session_stats',


### PR DESCRIPTION
# geo_fanout tool + classified retry/backoff policy (closes #104)

## Summary

This PR adds a resilient cross-country fetch primitive and, as its foundation,
the retry/backoff guidance requested in #104.

Two self-contained commits:

1. **`fix: classify gateway responses and add retry/backoff policy (closes #104)`**
   — the literal #104 fix; pure, table-tested helpers + wiring into the existing
   request path. Cherry-pick-clean on its own.
2. **`feat: add geo_fanout tool with first-class classified geo results`**
   — a new tool built on top of the #104 classification.

## What #104 asked for

Issue #104 reports intermittent `502 Bad Gateway` (and `504`) from the gateway
under burst load (~50-100 MCP calls), where *subsequent requests fail as well*,
and notes there is **no documented retry / backoff policy specific to MCP usage**.

The previous `base_request` retried on every non-4xx error **in a tight loop with
no delay** (`timeout: base_timeout` only), which under a burst can amplify the
overload rather than relieve it, and it had no notion of `Retry-After`.

## The fix (commit 1) — `retry_utils.js`

Three pure, dependency-free functions (no transport library coupling), each
table-tested:

- **`classify_response(input, now)`** — maps an HTTP response *or* a thrown
  transport error to a stable outcome taxonomy:
  - `success` (2xx)
  - `redirect` (3xx — follow the `Location`; not a retryable gateway error and
    not a hard fatal, so it gets its own self-consistent outcome rather than
    being mislabeled `fatal`)
  - `retryable` (408/425/500/502/503/504, unenumerated 5xx, and retryable
    network codes like `ECONNRESET`/`ETIMEDOUT`/`UND_ERR_CONNECT_TIMEOUT`)
  - `rate_limited` (429, surfacing `Retry-After`)
  - `blocked` (403/451 — a first-class terminal outcome, not a silent retry)
  - `client_error` (other 4xx — terminal)
  - `fatal` (unknown network code / unclassifiable — never silently retried)

  `parse_retry_after` accepts **only** a non-negative integer number of seconds
  or a valid HTTP-date; anything malformed (fractional `1.5`, negative `-3`,
  numeric-looking junk) returns `null` so the caller falls back to its computed
  backoff, rather than being read as a past date and clamped to an immediate
  retry.
- **`compute_backoff(attempt, opts, rng)`** — exponential backoff with **full
  jitter** (so a burst of concurrent callers does not retry in lockstep), capped
  at `max_ms`, and a server-supplied `Retry-After` (integer seconds *or*
  HTTP-date) always wins. `rng` is injectable for deterministic tests.
- **`should_retry(classification, attempt, max_retries, opts, rng)`** — combines
  the two into a `{retry, delay_ms}` decision honoring the retry budget.

`base_request` now uses these: only transient failures are retried, with jittered
backoff. New optional env knobs `BASE_BACKOFF_MS` (default 500) and
`MAX_BACKOFF_MS` (default 30000); the existing `BASE_MAX_RETRIES` still bounds the
attempt count.

## The feature (commit 2) — `geo_fanout`

`geo_fanout` fetches the **same URL from multiple country exits in parallel**
(via Web Unlocker's `country` targeting) and returns one structured report.
Crucially, a geo that is **blocked (403/451), redirected (3xx to a different
host), rate-limited (429), or fails transiently becomes a first-class classified
result** in the report — not a discarded error. This makes geo-gating and regional
price/availability/access differences observable at a glance.

Parameters: `url`, `countries` (1-10 deduped 2-letter ISO codes), optional
`data_format` (`markdown` default | `raw`). Registered in default/pro mode and the
`advanced_scraping` group. The aggregation logic lives in pure, table-tested
helpers in `geo_utils.js` (`normalize_geos`, `build_geo_entry`,
`summarize_fanout`).

Example result shape:

```json
{
  "summary": {"total": 3, "ok": 1, "blocked": 1, "redirected": 1,
              "rate_limited": 0, "error": 0},
  "any_blocked": true,
  "any_redirected": true,
  "results": [
    {"geo": "de", "status": "ok", "http_status": 200, "exit_ip": "...",
     "outcome": "success", "reason": "http 200", "redirect": null},
    {"geo": "be", "status": "blocked", "http_status": 403,
     "outcome": "blocked", "reason": "http 403 target blocked request"},
    {"geo": "fr", "status": "redirected", "http_status": 302,
     "outcome": "redirect",
     "redirect": {"redirected": true, "location": "...", "cross_host": true}}
  ]
}
```

## Tests

All table-driven, using the repo's existing `node --test` / `node:assert/strict`
setup. No new dependencies.

- `test/retry-utils.test.js` — `classify_response` taxonomy (26 cases incl. the
  502/504 from #104 and the 3xx `redirect` outcome), `parse_retry_after` (incl.
  strict rejection of fractional/negative/junk), `compute_backoff` (jitter modes
  + cap + Retry-After override), `should_retry` budget (incl. a 3xx never looping).
- `test/geo-utils.test.js` — `normalize_geos` (valid + loud-throw cases),
  `build_geo_entry` (every geo first-class), `summarize_fanout` (nothing dropped).
- `test/geo-fanout-tool.test.js` — boots the server over stdio and asserts the
  `geo_fanout` tool is registered with the correct schema.

Run: `npm test` → **15 tests, 15 pass, 0 fail.**

## Notes

- No crypto, no new runtime dependencies, MIT-compatible.
- Follows the repo's conventions (ES modules, `'use strict'; /*jslint ...*/`
  header, snake_case, single quotes, 4-space indent).
- Commit 1 is independently cherry-pickable (verified: applies cleanly to a fresh
  `main`, its tests pass standalone) for reviewers who want only the #104 fix.
