### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,14 @@ dependencies, and metadata from npm and PyPI without scraping:
 }
 ```
 
+For [Autohand Code](https://github.com/autohandai/code-cli/) on macOS, Linux, WSL, or Git Bash, add the same `code` tool group with:
+
+```bash
+autohand mcp add bright-data env API_TOKEN=your-token-here GROUPS=code npx @brightdata/mcp
+```
+
+Add `--scope project` before `bright-data` to save the server in the current project's `.autohand` configuration instead of your user configuration.
+
 ---
 
 ## ✨ Features


### PR DESCRIPTION
## What changed

Added an Autohand Code command to the existing coding-agent example for the `code` tool group.

## Why

The surrounding section already targets Claude Code, Cursor, and Windsurf. This gives Autohand Code users the same package-intelligence setup while preserving the existing token and group environment variables.

## Validation

- Verified the command against the current Autohand Code MCP CLI implementation
- Ran `git diff --check`
